### PR TITLE
Install git in the development step (Docker)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 # Versionamiento y metadata
-.git
 .gitignore
 .dockerignore
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM node:lts-bullseye-slim AS development
 
 # Instalar las dependencias necesarias para hot reloading
-RUN apt-get update && apt-get install -y procps openssl
+RUN apt-get update && apt-get install -y procps openssl git
 
 # Crear la carpeta de la app
 WORKDIR /usr/src/app


### PR DESCRIPTION
`.git` was removed from `.dockerignore` to allow the containerized development environment to access the Git repository. This is needed because if development is done entirely inside the container, node_modules will not exist on the host filesystem (since dependencies are installed inside the container). Since Husky relies on Git hooks, which are configured inside .git, if the container doesn't have access to the repository, Husky will not function properly, preventing commits from being made